### PR TITLE
feat: RoleSelectionScreen 구현 (#17)

### DIFF
--- a/app/src/main/java/com/ezlevup/ganbyeong24/presentation/navigation/NavGraph.kt
+++ b/app/src/main/java/com/ezlevup/ganbyeong24/presentation/navigation/NavGraph.kt
@@ -12,6 +12,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
+import com.ezlevup.ganbyeong24.presentation.screens.role.RoleSelectionScreen
 import com.ezlevup.ganbyeong24.presentation.screens.splash.SplashScreen
 import kotlinx.coroutines.delay
 
@@ -38,9 +39,9 @@ fun GanbyeongNavGraph(navController: NavHostController = rememberNavController()
 
         // 역할 선택 화면
         composable(Screen.RoleSelection.route) {
-            RoleSelectionScreenPlaceholder(
-                    onGuardianClick = { navController.navigate(Screen.CareRequest.route) },
-                    onCaregiverClick = {
+            RoleSelectionScreen(
+                    onGuardianSelected = { navController.navigate(Screen.CareRequest.route) },
+                    onCaregiverSelected = {
                         navController.navigate(Screen.CaregiverRegistration.route)
                     }
             )

--- a/app/src/main/java/com/ezlevup/ganbyeong24/presentation/screens/role/RoleSelectionScreen.kt
+++ b/app/src/main/java/com/ezlevup/ganbyeong24/presentation/screens/role/RoleSelectionScreen.kt
@@ -1,0 +1,103 @@
+package com.ezlevup.ganbyeong24.presentation.screens.role
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.ezlevup.ganbyeong24.presentation.theme.GanbyeongTheme
+
+/**
+ * 역할 선택 화면
+ *
+ * 사용자가 보호자 또는 간병사 역할을 선택할 수 있는 화면입니다.
+ *
+ * @param onGuardianSelected 보호자 선택 시 호출되는 콜백
+ * @param onCaregiverSelected 간병사 선택 시 호출되는 콜백
+ */
+@Composable
+fun RoleSelectionScreen(onGuardianSelected: () -> Unit, onCaregiverSelected: () -> Unit) {
+    Column(
+            modifier = Modifier.fillMaxSize().padding(24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+    ) {
+        // 제목
+        Text(
+                text = "간병24에 오신 것을\n환영합니다",
+                style = MaterialTheme.typography.headlineLarge,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.padding(bottom = 16.dp)
+        )
+
+        // 설명
+        Text(
+                text = "원하시는 서비스를 선택해주세요",
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
+                textAlign = TextAlign.Center,
+                modifier = Modifier.padding(bottom = 48.dp)
+        )
+
+        // 보호자 버튼
+        RoleButton(
+                icon = Icons.Default.Favorite,
+                text = "간병이 필요해요",
+                onClick = onGuardianSelected,
+                modifier = Modifier.padding(bottom = 16.dp)
+        )
+
+        // 간병사 버튼
+        RoleButton(icon = Icons.Default.Person, text = "간병사로 등록할게요", onClick = onCaregiverSelected)
+    }
+}
+
+/**
+ * 역할 선택 버튼
+ *
+ * 아이콘과 텍스트를 포함한 큰 버튼 컴포넌트입니다.
+ *
+ * @param icon 버튼에 표시할 아이콘
+ * @param text 버튼에 표시할 텍스트
+ * @param onClick 버튼 클릭 시 호출되는 콜백
+ * @param modifier Modifier
+ */
+@Composable
+private fun RoleButton(
+        icon: ImageVector,
+        text: String,
+        onClick: () -> Unit,
+        modifier: Modifier = Modifier
+) {
+    Button(
+            onClick = onClick,
+            modifier = modifier.fillMaxWidth().height(80.dp),
+            shape = RoundedCornerShape(12.dp),
+            colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary)
+    ) {
+        Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.Center
+        ) {
+            Icon(imageVector = icon, contentDescription = null, modifier = Modifier.size(32.dp))
+            Spacer(modifier = Modifier.width(16.dp))
+            Text(text = text, style = MaterialTheme.typography.headlineMedium)
+        }
+    }
+}
+
+// ========== Preview ==========
+
+@Preview(showBackground = true)
+@Composable
+private fun RoleSelectionScreenPreview() {
+    GanbyeongTheme { RoleSelectionScreen(onGuardianSelected = {}, onCaregiverSelected = {}) }
+}

--- a/docs/WorkLog.md
+++ b/docs/WorkLog.md
@@ -121,28 +121,33 @@
   - **해결**: 로고 이미지를 주석 처리하고 나중에 추가하기로 결정
   - **교훈**: 프리뷰와 실제 실행 환경의 차이 이해 필요
 
-### 🚧 진행 중인 작업
-- SplashScreen 마무리
-  - [ ] 로고 이미지 추가 (나중에)
-  - [ ] Git commit & push
-  - [ ] PR 생성 및 머지
+### ✅ 완료한 작업 (추가)
+
+#### SplashScreen 마무리
+- [x] **Issue #15 완료**: SplashScreen 개발 완료
+  - Git commit & push 완료
+  - PR 생성 및 머지 완료 (`feature/splash-screen` → `develop`)
+  - 브랜치 정리 완료
+  - 빌드 및 실행 테스트 성공
 
 ---
 
-## 🎯 다음 작업 (2026-01-15 오후 예정)
+## 🎯 다음 작업 (2026-01-15 오후)
 
 ### 3단계: 화면 개발 (계속)
 
-#### SplashScreen 마무리
-- [ ] Git commit & push
-- [ ] PR 생성 (`feature/splash-screen` → `develop`)
-- [ ] PR 머지 및 브랜치 정리
-
-#### RoleSelectionScreen 개발
-- [ ] GitHub 이슈 등록
+#### RoleSelectionScreen 개발 (다음 작업)
+- [ ] GitHub 이슈 등록 (#16 예정)
 - [ ] feature/role-selection 브랜치 생성
-- [ ] 역할 선택 UI 구현
-- [ ] 보호자/간병사 버튼 디자인
+- [ ] RoleSelectionScreen.kt 구현
+  - [ ] "보호자" 버튼 (간병 신청)
+  - [ ] "간병사" 버튼 (간병사 등록)
+  - [ ] 버튼 디자인 및 아이콘
+  - [ ] 네비게이션 연결
+- [ ] NavGraph 업데이트
+- [ ] 빌드 및 테스트
+- [ ] Git commit & push
+- [ ] PR 생성 및 머지
 
 #### CareRequestScreen 개발 (시간 되면)
 - [ ] 간병 신청 폼 구현
@@ -155,14 +160,13 @@
 ### 전체 로드맵 (5단계)
 - ✅ 1단계: 프로젝트 초기 설정 (100%)
 - ✅ 2단계: 기반 구축 (100%)
-- 🚧 3단계: 화면 개발 (20% - SplashScreen 완료)
+- 🚧 3단계: 화면 개발 (20% - SplashScreen 완료, RoleSelectionScreen 준비 중)
 - ⏳ 4단계: 데이터 레이어 (0%)
 - ⏳ 5단계: 테스트 및 배포 (0%)
 
 ### GitHub Issues
-- ✅ Closed: #1, #2, #3, #4, #5, #6, #13
-- � In Progress: #15 (SplashScreen)
-- �📝 Next: RoleSelectionScreen, CareRequestScreen
+- ✅ Closed: #1, #2, #3, #4, #5, #6, #13, #15
+- 📝 Next: #16 (RoleSelectionScreen), CareRequestScreen
 
 ---
 
@@ -238,5 +242,5 @@ docs/WorkLog.md 파일 확인해줘.
 
 ---
 
-**마지막 업데이트**: 2026-01-15 13:47
+**마지막 업데이트**: 2026-01-15 14:13
 

--- a/issue_role_selection.md
+++ b/issue_role_selection.md
@@ -1,0 +1,32 @@
+## 🎯 작업 내용
+RoleSelectionScreen 구현 - 역할 선택 화면
+
+## 📋 상세 설명
+사용자가 보호자 또는 간병사 역할을 선택할 수 있는 화면을 구현합니다.
+
+## ✅ 구현 사항
+- [ ] RoleSelectionScreen.kt 파일 생성
+- [ ] 화면 UI 구성
+  - 제목: "역할을 선택해주세요"
+  - 설명 텍스트: 간단한 안내 문구
+  - "보호자" 버튼 (간병 신청)
+  - "간병사" 버튼 (간병사 등록)
+  - 각 버튼에 적절한 아이콘 추가
+- [ ] 네비게이션 연결
+  - 보호자 선택 → CareRequestScreen으로 이동
+  - 간병사 선택 → CaregiverRegistrationScreen으로 이동
+- [ ] NavGraph.kt 업데이트
+  - RoleSelectionScreenPlaceholder를 실제 RoleSelectionScreen으로 교체
+
+## 🎨 디자인 요구사항
+- Material3 테마 적용
+- 시니어 친화적 큰 버튼 (높이 56dp 이상)
+- 명확한 아이콘과 텍스트
+- 적절한 간격과 여백
+
+## 📝 참고 문서
+- [ScreenDesign.md](./docs/ScreenDesign.md)
+- [TechnicalDesign.md](./docs/TechnicalDesign.md)
+
+## 🔗 관련 이슈
+- #15 (SplashScreen 구현)


### PR DESCRIPTION
## 🎯 작업 내용
RoleSelectionScreen 구현 (#17)
## ✅ 구현 사항
- RoleSelectionScreen.kt 파일 생성
- 역할 선택 UI 구현 (보호자/간병사)
- 제목: \"간병24에 오신 것을 환영합니다\"
- 설명: \"원하시는 서비스를 선택해주세요\"
- 보호자 버튼: \"간병이 필요해요\" (하트 아이콘)
- 간병사 버튼: \"간병사로 등록할게요\" (사람 아이콘)
- NavGraph.kt 업데이트 (Placeholder → 실제 화면)
- 시니어 친화적 큰 버튼 (높이 80dp)
## 📋 테스트
- [x] 빌드 성공
- [x] 앱 실행 시 SplashScreen → RoleSelectionScreen 전환 확인
- [x] UI 정상 표시 확인
- [x] 네비게이션 정상 작동 확인
## 📝 관련 이슈
Closes #17"
