### PR TITLE
feat: CareRequestScreen 구현 (#19)

### DIFF
--- a/app/src/main/java/com/ezlevup/ganbyeong24/data/model/CareRequest.kt
+++ b/app/src/main/java/com/ezlevup/ganbyeong24/data/model/CareRequest.kt
@@ -1,0 +1,34 @@
+package com.ezlevup.ganbyeong24.data.model
+
+import com.google.firebase.Timestamp
+
+/**
+ * 간병 신청 데이터 모델
+ *
+ * Firestore에 저장되는 간병 신청 정보를 나타냅니다.
+ *
+ * @property id Firestore 문서 ID
+ * @property patientName 환자명
+ * @property guardianName 보호자명
+ * @property patientCondition 환자 상태
+ * @property careStartDate 간병 시작일
+ * @property careEndDate 간병 종료일
+ * @property location 간병 위치
+ * @property patientPhoneNumber 환자 연락처 (선택)
+ * @property guardianPhoneNumber 보호자 연락처 (필수)
+ * @property status 신청 상태 (pending, approved, rejected)
+ * @property createdAt 생성 시간
+ */
+data class CareRequest(
+        val id: String = "",
+        val patientName: String = "",
+        val guardianName: String = "",
+        val patientCondition: String = "",
+        val careStartDate: String = "",
+        val careEndDate: String = "",
+        val location: String = "",
+        val patientPhoneNumber: String? = null,
+        val guardianPhoneNumber: String = "",
+        val status: String = "pending",
+        val createdAt: Timestamp = Timestamp.now()
+)

--- a/app/src/main/java/com/ezlevup/ganbyeong24/data/repository/CareRequestRepository.kt
+++ b/app/src/main/java/com/ezlevup/ganbyeong24/data/repository/CareRequestRepository.kt
@@ -1,0 +1,18 @@
+package com.ezlevup.ganbyeong24.data.repository
+
+import com.ezlevup.ganbyeong24.data.model.CareRequest
+
+/**
+ * 간병 신청 Repository 인터페이스
+ *
+ * 간병 신청 데이터의 저장 및 조회를 담당합니다.
+ */
+interface CareRequestRepository {
+    /**
+     * 간병 신청 정보를 저장합니다.
+     *
+     * @param request 저장할 간병 신청 정보
+     * @return Result<String> 성공 시 문서 ID, 실패 시 에러
+     */
+    suspend fun saveCareRequest(request: CareRequest): Result<String>
+}

--- a/app/src/main/java/com/ezlevup/ganbyeong24/data/repository/CareRequestRepositoryImpl.kt
+++ b/app/src/main/java/com/ezlevup/ganbyeong24/data/repository/CareRequestRepositoryImpl.kt
@@ -1,0 +1,38 @@
+package com.ezlevup.ganbyeong24.data.repository
+
+import com.ezlevup.ganbyeong24.data.model.CareRequest
+import com.google.firebase.firestore.FirebaseFirestore
+import kotlinx.coroutines.tasks.await
+
+/**
+ * 간병 신청 Repository 구현체
+ *
+ * Firestore를 사용하여 간병 신청 데이터를 저장합니다.
+ *
+ * @property firestore Firebase Firestore 인스턴스
+ */
+class CareRequestRepositoryImpl(private val firestore: FirebaseFirestore) : CareRequestRepository {
+
+    companion object {
+        private const val COLLECTION_NAME = "care_requests"
+    }
+
+    /**
+     * 간병 신청 정보를 Firestore에 저장합니다.
+     *
+     * @param request 저장할 간병 신청 정보
+     * @return Result<String> 성공 시 생성된 문서 ID, 실패 시 에러
+     */
+    override suspend fun saveCareRequest(request: CareRequest): Result<String> {
+        return try {
+            // Firestore에 새 문서 추가
+            val documentRef = firestore.collection(COLLECTION_NAME).add(request).await()
+
+            // 생성된 문서 ID 반환
+            Result.success(documentRef.id)
+        } catch (e: Exception) {
+            // 에러 발생 시 Result.failure 반환
+            Result.failure(e)
+        }
+    }
+}

--- a/app/src/main/java/com/ezlevup/ganbyeong24/di/AppModule.kt
+++ b/app/src/main/java/com/ezlevup/ganbyeong24/di/AppModule.kt
@@ -1,6 +1,10 @@
 package com.ezlevup.ganbyeong24.di
 
+import com.ezlevup.ganbyeong24.data.repository.CareRequestRepository
+import com.ezlevup.ganbyeong24.data.repository.CareRequestRepositoryImpl
+import com.ezlevup.ganbyeong24.presentation.screens.care_request.CareRequestViewModel
 import com.google.firebase.firestore.FirebaseFirestore
+import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.dsl.module
 
 /**
@@ -13,11 +17,13 @@ val appModule = module {
     // Firebase Firestore 인스턴스
     single { FirebaseFirestore.getInstance() }
 
-    // TODO: Repository 추가 (4단계에서 구현)
-    // single<CareRequestRepository> { CareRequestRepositoryImpl(get()) }
+    // Repository
+    single<CareRequestRepository> { CareRequestRepositoryImpl(get()) }
+    // TODO: CaregiverRepository 추가 (나중에 구현)
     // single<CaregiverRepository> { CaregiverRepositoryImpl(get()) }
 
-    // TODO: ViewModel 추가 (4단계에서 구현)
-    // viewModel { CareRequestViewModel(get()) }
+    // ViewModel
+    viewModel { CareRequestViewModel(get()) }
+    // TODO: CaregiverViewModel 추가 (나중에 구현)
     // viewModel { CaregiverViewModel(get()) }
 }

--- a/app/src/main/java/com/ezlevup/ganbyeong24/presentation/navigation/NavGraph.kt
+++ b/app/src/main/java/com/ezlevup/ganbyeong24/presentation/navigation/NavGraph.kt
@@ -12,6 +12,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
+import com.ezlevup.ganbyeong24.presentation.screens.care_request.CareRequestScreen
 import com.ezlevup.ganbyeong24.presentation.screens.role.RoleSelectionScreen
 import com.ezlevup.ganbyeong24.presentation.screens.splash.SplashScreen
 import kotlinx.coroutines.delay
@@ -49,8 +50,9 @@ fun GanbyeongNavGraph(navController: NavHostController = rememberNavController()
 
         // 간병 신청 화면
         composable(Screen.CareRequest.route) {
-            CareRequestScreenPlaceholder(
-                    onSubmitSuccess = {
+            CareRequestScreen(
+                    onNavigateBack = { navController.popBackStack() },
+                    onSuccess = {
                         navController.navigate(Screen.Result.createRoute("guardian")) {
                             popUpTo(Screen.RoleSelection.route)
                         }

--- a/app/src/main/java/com/ezlevup/ganbyeong24/presentation/screens/care_request/CareRequestScreen.kt
+++ b/app/src/main/java/com/ezlevup/ganbyeong24/presentation/screens/care_request/CareRequestScreen.kt
@@ -1,0 +1,323 @@
+package com.ezlevup.ganbyeong24.presentation.screens.care_request
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.ezlevup.ganbyeong24.presentation.components.GanbyeongButton
+import com.ezlevup.ganbyeong24.presentation.components.GanbyeongTextField
+import com.ezlevup.ganbyeong24.presentation.theme.GanbyeongTheme
+import org.koin.androidx.compose.koinViewModel
+
+/**
+ * 간병 신청 화면
+ *
+ * 보호자가 간병 서비스를 신청할 수 있는 화면입니다.
+ *
+ * @param viewModel 간병 신청 ViewModel
+ * @param onNavigateBack 뒤로가기 콜백
+ * @param onSuccess 신청 성공 시 호출되는 콜백
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CareRequestScreen(
+        viewModel: CareRequestViewModel = koinViewModel(),
+        onNavigateBack: () -> Unit = {},
+        onSuccess: () -> Unit
+) {
+    val state by viewModel.state.collectAsState()
+
+    // 신청 성공 시 ResultScreen으로 이동
+    LaunchedEffect(state.isSuccess) {
+        if (state.isSuccess) {
+            onSuccess()
+        }
+    }
+
+    Scaffold(
+            topBar = {
+                TopAppBar(
+                        title = { Text("간병 신청") },
+                        navigationIcon = {
+                            IconButton(onClick = onNavigateBack) {
+                                Icon(Icons.Default.ArrowBack, contentDescription = "뒤로가기")
+                            }
+                        }
+                )
+            }
+    ) { padding ->
+        Column(
+                modifier =
+                        Modifier.fillMaxSize()
+                                .padding(padding)
+                                .verticalScroll(rememberScrollState())
+                                .padding(24.dp)
+        ) {
+            // 환자명
+            GanbyeongTextField(
+                    value = state.patientName,
+                    onValueChange = viewModel::onPatientNameChange,
+                    label = "환자명 *",
+                    placeholder = "예: 홍길동",
+                    isError = state.patientNameError != null,
+                    errorMessage = state.patientNameError,
+                    modifier = Modifier.padding(bottom = 16.dp)
+            )
+
+            // 보호자명
+            GanbyeongTextField(
+                    value = state.guardianName,
+                    onValueChange = viewModel::onGuardianNameChange,
+                    label = "보호자명 *",
+                    placeholder = "예: 김철수",
+                    isError = state.guardianNameError != null,
+                    errorMessage = state.guardianNameError,
+                    modifier = Modifier.padding(bottom = 16.dp)
+            )
+
+            // 환자 상태
+            GanbyeongTextField(
+                    value = state.patientCondition,
+                    onValueChange = viewModel::onPatientConditionChange,
+                    label = "환자 상태 *",
+                    placeholder = "예: 거동 가능",
+                    isError = state.patientConditionError != null,
+                    errorMessage = state.patientConditionError,
+                    modifier = Modifier.padding(bottom = 16.dp)
+            )
+
+            // 간병 시작일
+            GanbyeongTextField(
+                    value = state.careStartDate,
+                    onValueChange = viewModel::onCareStartDateChange,
+                    label = "간병 시작일 *",
+                    placeholder = "예: 2024-01-15",
+                    isError = state.careStartDateError != null,
+                    errorMessage = state.careStartDateError,
+                    modifier = Modifier.padding(bottom = 16.dp)
+            )
+
+            // 간병 종료일
+            GanbyeongTextField(
+                    value = state.careEndDate,
+                    onValueChange = viewModel::onCareEndDateChange,
+                    label = "간병 종료일 *",
+                    placeholder = "예: 2024-01-30",
+                    isError = state.careEndDateError != null,
+                    errorMessage = state.careEndDateError,
+                    modifier = Modifier.padding(bottom = 16.dp)
+            )
+
+            // 위치
+            GanbyeongTextField(
+                    value = state.location,
+                    onValueChange = viewModel::onLocationChange,
+                    label = "위치 *",
+                    placeholder = "예: 서울시 강남구",
+                    isError = state.locationError != null,
+                    errorMessage = state.locationError,
+                    modifier = Modifier.padding(bottom = 16.dp)
+            )
+
+            // 환자 연락처 (선택)
+            GanbyeongTextField(
+                    value = state.patientPhoneNumber,
+                    onValueChange = viewModel::onPatientPhoneNumberChange,
+                    label = "환자 연락처 (선택)",
+                    placeholder = "010-1234-5678",
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Phone),
+                    modifier = Modifier.padding(bottom = 16.dp)
+            )
+
+            // 보호자 연락처 (필수)
+            GanbyeongTextField(
+                    value = state.guardianPhoneNumber,
+                    onValueChange = viewModel::onGuardianPhoneNumberChange,
+                    label = "보호자 연락처 *",
+                    placeholder = "010-9876-5432",
+                    isError = state.guardianPhoneNumberError != null,
+                    errorMessage = state.guardianPhoneNumberError,
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Phone),
+                    modifier = Modifier.padding(bottom = 32.dp)
+            )
+
+            // 신청 버튼
+            GanbyeongButton(
+                    text = "신청하기",
+                    onClick = viewModel::submitCareRequest,
+                    isLoading = state.isLoading
+            )
+        }
+    }
+
+    // 에러 다이얼로그
+    if (state.errorMessage != null) {
+        AlertDialog(
+                onDismissRequest = viewModel::clearError,
+                title = { Text("오류") },
+                text = { Text(state.errorMessage!!) },
+                confirmButton = { TextButton(onClick = viewModel::clearError) { Text("확인") } }
+        )
+    }
+}
+
+// ========== Preview ==========
+
+@Preview(showBackground = true)
+@Composable
+private fun CareRequestScreenPreview() {
+    GanbyeongTheme {
+        // Preview는 ViewModel 없이 표시
+        CareRequestScreenContent(
+                state = CareRequestState(),
+                onPatientNameChange = {},
+                onGuardianNameChange = {},
+                onPatientConditionChange = {},
+                onCareStartDateChange = {},
+                onCareEndDateChange = {},
+                onLocationChange = {},
+                onPatientPhoneNumberChange = {},
+                onGuardianPhoneNumberChange = {},
+                onSubmit = {},
+                onNavigateBack = {},
+                onClearError = {}
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun CareRequestScreenContent(
+        state: CareRequestState,
+        onPatientNameChange: (String) -> Unit,
+        onGuardianNameChange: (String) -> Unit,
+        onPatientConditionChange: (String) -> Unit,
+        onCareStartDateChange: (String) -> Unit,
+        onCareEndDateChange: (String) -> Unit,
+        onLocationChange: (String) -> Unit,
+        onPatientPhoneNumberChange: (String) -> Unit,
+        onGuardianPhoneNumberChange: (String) -> Unit,
+        onSubmit: () -> Unit,
+        onNavigateBack: () -> Unit,
+        onClearError: () -> Unit
+) {
+    Scaffold(
+            topBar = {
+                TopAppBar(
+                        title = { Text("간병 신청") },
+                        navigationIcon = {
+                            IconButton(onClick = onNavigateBack) {
+                                Icon(Icons.Default.ArrowBack, contentDescription = "뒤로가기")
+                            }
+                        }
+                )
+            }
+    ) { padding ->
+        Column(
+                modifier =
+                        Modifier.fillMaxSize()
+                                .padding(padding)
+                                .verticalScroll(rememberScrollState())
+                                .padding(24.dp)
+        ) {
+            GanbyeongTextField(
+                    value = state.patientName,
+                    onValueChange = onPatientNameChange,
+                    label = "환자명 *",
+                    placeholder = "예: 홍길동",
+                    isError = state.patientNameError != null,
+                    errorMessage = state.patientNameError,
+                    modifier = Modifier.padding(bottom = 16.dp)
+            )
+
+            GanbyeongTextField(
+                    value = state.guardianName,
+                    onValueChange = onGuardianNameChange,
+                    label = "보호자명 *",
+                    placeholder = "예: 김철수",
+                    isError = state.guardianNameError != null,
+                    errorMessage = state.guardianNameError,
+                    modifier = Modifier.padding(bottom = 16.dp)
+            )
+
+            GanbyeongTextField(
+                    value = state.patientCondition,
+                    onValueChange = onPatientConditionChange,
+                    label = "환자 상태 *",
+                    placeholder = "예: 거동 가능",
+                    isError = state.patientConditionError != null,
+                    errorMessage = state.patientConditionError,
+                    modifier = Modifier.padding(bottom = 16.dp)
+            )
+
+            GanbyeongTextField(
+                    value = state.careStartDate,
+                    onValueChange = onCareStartDateChange,
+                    label = "간병 시작일 *",
+                    placeholder = "예: 2024-01-15",
+                    isError = state.careStartDateError != null,
+                    errorMessage = state.careStartDateError,
+                    modifier = Modifier.padding(bottom = 16.dp)
+            )
+
+            GanbyeongTextField(
+                    value = state.careEndDate,
+                    onValueChange = onCareEndDateChange,
+                    label = "간병 종료일 *",
+                    placeholder = "예: 2024-01-30",
+                    isError = state.careEndDateError != null,
+                    errorMessage = state.careEndDateError,
+                    modifier = Modifier.padding(bottom = 16.dp)
+            )
+
+            GanbyeongTextField(
+                    value = state.location,
+                    onValueChange = onLocationChange,
+                    label = "위치 *",
+                    placeholder = "예: 서울시 강남구",
+                    isError = state.locationError != null,
+                    errorMessage = state.locationError,
+                    modifier = Modifier.padding(bottom = 16.dp)
+            )
+
+            GanbyeongTextField(
+                    value = state.patientPhoneNumber,
+                    onValueChange = onPatientPhoneNumberChange,
+                    label = "환자 연락처 (선택)",
+                    placeholder = "010-1234-5678",
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Phone),
+                    modifier = Modifier.padding(bottom = 16.dp)
+            )
+
+            GanbyeongTextField(
+                    value = state.guardianPhoneNumber,
+                    onValueChange = onGuardianPhoneNumberChange,
+                    label = "보호자 연락처 *",
+                    placeholder = "010-9876-5432",
+                    isError = state.guardianPhoneNumberError != null,
+                    errorMessage = state.guardianPhoneNumberError,
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Phone),
+                    modifier = Modifier.padding(bottom = 32.dp)
+            )
+
+            GanbyeongButton(text = "신청하기", onClick = onSubmit, isLoading = state.isLoading)
+        }
+    }
+
+    if (state.errorMessage != null) {
+        AlertDialog(
+                onDismissRequest = onClearError,
+                title = { Text("오류") },
+                text = { Text(state.errorMessage) },
+                confirmButton = { TextButton(onClick = onClearError) { Text("확인") } }
+        )
+    }
+}

--- a/app/src/main/java/com/ezlevup/ganbyeong24/presentation/screens/care_request/CareRequestState.kt
+++ b/app/src/main/java/com/ezlevup/ganbyeong24/presentation/screens/care_request/CareRequestState.kt
@@ -1,0 +1,46 @@
+package com.ezlevup.ganbyeong24.presentation.screens.care_request
+
+/**
+ * 간병 신청 화면 상태
+ *
+ * 화면의 모든 상태를 관리하는 데이터 클래스입니다.
+ *
+ * @property isLoading 로딩 상태
+ * @property isSuccess 신청 성공 여부
+ * @property errorMessage 에러 메시지
+ * @property patientName 환자명
+ * @property guardianName 보호자명
+ * @property patientCondition 환자 상태
+ * @property careStartDate 간병 시작일
+ * @property careEndDate 간병 종료일
+ * @property location 위치
+ * @property patientPhoneNumber 환자 연락처
+ * @property guardianPhoneNumber 보호자 연락처
+ * @property patientNameError 환자명 에러 메시지
+ * @property guardianNameError 보호자명 에러 메시지
+ * @property patientConditionError 환자 상태 에러 메시지
+ * @property careStartDateError 간병 시작일 에러 메시지
+ * @property careEndDateError 간병 종료일 에러 메시지
+ * @property locationError 위치 에러 메시지
+ * @property guardianPhoneNumberError 보호자 연락처 에러 메시지
+ */
+data class CareRequestState(
+        val isLoading: Boolean = false,
+        val isSuccess: Boolean = false,
+        val errorMessage: String? = null,
+        val patientName: String = "",
+        val guardianName: String = "",
+        val patientCondition: String = "",
+        val careStartDate: String = "",
+        val careEndDate: String = "",
+        val location: String = "",
+        val patientPhoneNumber: String = "",
+        val guardianPhoneNumber: String = "",
+        val patientNameError: String? = null,
+        val guardianNameError: String? = null,
+        val patientConditionError: String? = null,
+        val careStartDateError: String? = null,
+        val careEndDateError: String? = null,
+        val locationError: String? = null,
+        val guardianPhoneNumberError: String? = null
+)

--- a/app/src/main/java/com/ezlevup/ganbyeong24/presentation/screens/care_request/CareRequestViewModel.kt
+++ b/app/src/main/java/com/ezlevup/ganbyeong24/presentation/screens/care_request/CareRequestViewModel.kt
@@ -1,0 +1,164 @@
+package com.ezlevup.ganbyeong24.presentation.screens.care_request
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.ezlevup.ganbyeong24.data.model.CareRequest
+import com.ezlevup.ganbyeong24.data.repository.CareRequestRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+/**
+ * 간병 신청 화면 ViewModel
+ *
+ * 간병 신청 화면의 비즈니스 로직을 담당합니다.
+ *
+ * @property repository 간병 신청 Repository
+ */
+class CareRequestViewModel(private val repository: CareRequestRepository) : ViewModel() {
+
+    private val _state = MutableStateFlow(CareRequestState())
+    val state: StateFlow<CareRequestState> = _state.asStateFlow()
+
+    // ========== 입력 핸들러 ==========
+
+    fun onPatientNameChange(name: String) {
+        _state.update { it.copy(patientName = name, patientNameError = null) }
+    }
+
+    fun onGuardianNameChange(name: String) {
+        _state.update { it.copy(guardianName = name, guardianNameError = null) }
+    }
+
+    fun onPatientConditionChange(condition: String) {
+        _state.update { it.copy(patientCondition = condition, patientConditionError = null) }
+    }
+
+    fun onCareStartDateChange(date: String) {
+        _state.update { it.copy(careStartDate = date, careStartDateError = null) }
+    }
+
+    fun onCareEndDateChange(date: String) {
+        _state.update { it.copy(careEndDate = date, careEndDateError = null) }
+    }
+
+    fun onLocationChange(location: String) {
+        _state.update { it.copy(location = location, locationError = null) }
+    }
+
+    fun onPatientPhoneNumberChange(phoneNumber: String) {
+        _state.update { it.copy(patientPhoneNumber = phoneNumber) }
+    }
+
+    fun onGuardianPhoneNumberChange(phoneNumber: String) {
+        _state.update {
+            it.copy(guardianPhoneNumber = phoneNumber, guardianPhoneNumberError = null)
+        }
+    }
+
+    // ========== 신청 처리 ==========
+
+    /** 간병 신청을 제출합니다. */
+    fun submitCareRequest() {
+        if (!validateForm()) return
+
+        viewModelScope.launch {
+            _state.update { it.copy(isLoading = true) }
+
+            val request =
+                    CareRequest(
+                            patientName = _state.value.patientName,
+                            guardianName = _state.value.guardianName,
+                            patientCondition = _state.value.patientCondition,
+                            careStartDate = _state.value.careStartDate,
+                            careEndDate = _state.value.careEndDate,
+                            location = _state.value.location,
+                            patientPhoneNumber = _state.value.patientPhoneNumber.ifBlank { null },
+                            guardianPhoneNumber = _state.value.guardianPhoneNumber,
+                            status = "pending"
+                    )
+
+            repository
+                    .saveCareRequest(request)
+                    .onSuccess { _state.update { it.copy(isLoading = false, isSuccess = true) } }
+                    .onFailure { error ->
+                        _state.update {
+                            it.copy(
+                                    isLoading = false,
+                                    errorMessage = error.message ?: "알 수 없는 오류가 발생했습니다"
+                            )
+                        }
+                    }
+        }
+    }
+
+    // ========== 유효성 검사 ==========
+
+    /**
+     * 폼 유효성 검사를 수행합니다.
+     *
+     * @return 유효성 검사 통과 여부
+     */
+    private fun validateForm(): Boolean {
+        val errors = mutableMapOf<String, String>()
+
+        // 환자명 검증
+        if (_state.value.patientName.length < 2) {
+            errors["patientName"] = "환자명은 2자 이상 입력해주세요"
+        }
+
+        // 보호자명 검증
+        if (_state.value.guardianName.length < 2) {
+            errors["guardianName"] = "보호자명은 2자 이상 입력해주세요"
+        }
+
+        // 환자 상태 검증
+        if (_state.value.patientCondition.isBlank()) {
+            errors["patientCondition"] = "환자 상태를 입력해주세요"
+        }
+
+        // 간병 시작일 검증
+        if (_state.value.careStartDate.isBlank()) {
+            errors["careStartDate"] = "간병 시작일을 입력해주세요"
+        }
+
+        // 간병 종료일 검증
+        if (_state.value.careEndDate.isBlank()) {
+            errors["careEndDate"] = "간병 종료일을 입력해주세요"
+        }
+
+        // 위치 검증
+        if (_state.value.location.isBlank()) {
+            errors["location"] = "위치를 입력해주세요"
+        }
+
+        // 보호자 연락처 검증
+        val phoneRegex = "^010\\d{8}$".toRegex()
+        val cleanPhone = _state.value.guardianPhoneNumber.replace("-", "")
+        if (!phoneRegex.matches(cleanPhone)) {
+            errors["guardianPhoneNumber"] = "올바른 전화번호 형식이 아닙니다 (010-XXXX-XXXX)"
+        }
+
+        // 에러 업데이트
+        _state.update {
+            it.copy(
+                    patientNameError = errors["patientName"],
+                    guardianNameError = errors["guardianName"],
+                    patientConditionError = errors["patientCondition"],
+                    careStartDateError = errors["careStartDate"],
+                    careEndDateError = errors["careEndDate"],
+                    locationError = errors["location"],
+                    guardianPhoneNumberError = errors["guardianPhoneNumber"]
+            )
+        }
+
+        return errors.isEmpty()
+    }
+
+    /** 에러 메시지를 초기화합니다. */
+    fun clearError() {
+        _state.update { it.copy(errorMessage = null) }
+    }
+}


### PR DESCRIPTION
## 🎯 작업 내용
CareRequestScreen 구현 (#19)
## ✅ 구현 사항
### 데이터 레이어
- CareRequest 데이터 모델 생성
- CareRequestRepository 인터페이스 및 구현체
- Firestore 연동
### Presentation 레이어
- CareRequestState 데이터 클래스
- CareRequestViewModel (상태 관리, 유효성 검사)
### UI 레이어
- CareRequestScreen.kt (8개 입력 필드)
- TopAppBar 및 뒤로가기 기능
- 유효성 검사 에러 메시지 표시
- 로딩 상태 처리
- 에러 다이얼로그
### Koin DI 설정
- Repository 및 ViewModel 등록
### Navigation
- CareRequestScreenPlaceholder → 실제 화면 교체
## 📋 테스트
- [x] 빌드 성공
- [x] UI 정상 표시 확인
- [x] 입력 필드 동작 확인
- [x] 유효성 검사 확인
- [x] Firestore 저장 확인
## 📝 관련 이슈
Closes #19