### PR TITLE
feat: CaregiverRegistrationScreen 구현 (#21)

### DIFF
--- a/app/src/main/java/com/ezlevup/ganbyeong24/data/model/Caregiver.kt
+++ b/app/src/main/java/com/ezlevup/ganbyeong24/data/model/Caregiver.kt
@@ -1,0 +1,28 @@
+package com.ezlevup.ganbyeong24.data.model
+
+import com.google.firebase.Timestamp
+
+/**
+ * 간병사 데이터 모델
+ *
+ * Firestore에 저장되는 간병사 정보를 나타냅니다.
+ *
+ * @property id Firestore 문서 ID
+ * @property name 이름
+ * @property experience 경력
+ * @property certificates 자격증
+ * @property availableRegions 가능 지역
+ * @property phoneNumber 연락처
+ * @property status 등록 상태 (pending, approved, rejected)
+ * @property createdAt 생성 시간
+ */
+data class Caregiver(
+        val id: String = "",
+        val name: String = "",
+        val experience: String = "",
+        val certificates: String = "",
+        val availableRegions: String = "",
+        val phoneNumber: String = "",
+        val status: String = "pending",
+        val createdAt: Timestamp = Timestamp.now()
+)

--- a/app/src/main/java/com/ezlevup/ganbyeong24/data/repository/CaregiverRepository.kt
+++ b/app/src/main/java/com/ezlevup/ganbyeong24/data/repository/CaregiverRepository.kt
@@ -1,0 +1,18 @@
+package com.ezlevup.ganbyeong24.data.repository
+
+import com.ezlevup.ganbyeong24.data.model.Caregiver
+
+/**
+ * 간병사 Repository 인터페이스
+ *
+ * 간병사 데이터의 저장 및 조회를 담당합니다.
+ */
+interface CaregiverRepository {
+    /**
+     * 간병사 정보를 저장합니다.
+     *
+     * @param caregiver 저장할 간병사 정보
+     * @return Result<String> 성공 시 문서 ID, 실패 시 에러
+     */
+    suspend fun saveCaregiver(caregiver: Caregiver): Result<String>
+}

--- a/app/src/main/java/com/ezlevup/ganbyeong24/data/repository/CaregiverRepositoryImpl.kt
+++ b/app/src/main/java/com/ezlevup/ganbyeong24/data/repository/CaregiverRepositoryImpl.kt
@@ -1,0 +1,38 @@
+package com.ezlevup.ganbyeong24.data.repository
+
+import com.ezlevup.ganbyeong24.data.model.Caregiver
+import com.google.firebase.firestore.FirebaseFirestore
+import kotlinx.coroutines.tasks.await
+
+/**
+ * 간병사 Repository 구현체
+ *
+ * Firestore를 사용하여 간병사 데이터를 저장합니다.
+ *
+ * @property firestore Firebase Firestore 인스턴스
+ */
+class CaregiverRepositoryImpl(private val firestore: FirebaseFirestore) : CaregiverRepository {
+
+    companion object {
+        private const val COLLECTION_NAME = "caregivers"
+    }
+
+    /**
+     * 간병사 정보를 Firestore에 저장합니다.
+     *
+     * @param caregiver 저장할 간병사 정보
+     * @return Result<String> 성공 시 생성된 문서 ID, 실패 시 에러
+     */
+    override suspend fun saveCaregiver(caregiver: Caregiver): Result<String> {
+        return try {
+            // Firestore에 새 문서 추가
+            val documentRef = firestore.collection(COLLECTION_NAME).add(caregiver).await()
+
+            // 생성된 문서 ID 반환
+            Result.success(documentRef.id)
+        } catch (e: Exception) {
+            // 에러 발생 시 Result.failure 반환
+            Result.failure(e)
+        }
+    }
+}

--- a/app/src/main/java/com/ezlevup/ganbyeong24/di/AppModule.kt
+++ b/app/src/main/java/com/ezlevup/ganbyeong24/di/AppModule.kt
@@ -2,7 +2,10 @@ package com.ezlevup.ganbyeong24.di
 
 import com.ezlevup.ganbyeong24.data.repository.CareRequestRepository
 import com.ezlevup.ganbyeong24.data.repository.CareRequestRepositoryImpl
+import com.ezlevup.ganbyeong24.data.repository.CaregiverRepository
+import com.ezlevup.ganbyeong24.data.repository.CaregiverRepositoryImpl
 import com.ezlevup.ganbyeong24.presentation.screens.care_request.CareRequestViewModel
+import com.ezlevup.ganbyeong24.presentation.screens.caregiver.CaregiverRegistrationViewModel
 import com.google.firebase.firestore.FirebaseFirestore
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.dsl.module
@@ -19,11 +22,9 @@ val appModule = module {
 
     // Repository
     single<CareRequestRepository> { CareRequestRepositoryImpl(get()) }
-    // TODO: CaregiverRepository 추가 (나중에 구현)
-    // single<CaregiverRepository> { CaregiverRepositoryImpl(get()) }
+    single<CaregiverRepository> { CaregiverRepositoryImpl(get()) }
 
     // ViewModel
     viewModel { CareRequestViewModel(get()) }
-    // TODO: CaregiverViewModel 추가 (나중에 구현)
-    // viewModel { CaregiverViewModel(get()) }
+    viewModel { CaregiverRegistrationViewModel(get()) }
 }

--- a/app/src/main/java/com/ezlevup/ganbyeong24/presentation/navigation/NavGraph.kt
+++ b/app/src/main/java/com/ezlevup/ganbyeong24/presentation/navigation/NavGraph.kt
@@ -13,6 +13,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
 import com.ezlevup.ganbyeong24.presentation.screens.care_request.CareRequestScreen
+import com.ezlevup.ganbyeong24.presentation.screens.caregiver.CaregiverRegistrationScreen
 import com.ezlevup.ganbyeong24.presentation.screens.role.RoleSelectionScreen
 import com.ezlevup.ganbyeong24.presentation.screens.splash.SplashScreen
 import kotlinx.coroutines.delay
@@ -62,8 +63,9 @@ fun GanbyeongNavGraph(navController: NavHostController = rememberNavController()
 
         // 간병사 등록 화면
         composable(Screen.CaregiverRegistration.route) {
-            CaregiverRegistrationScreenPlaceholder(
-                    onSubmitSuccess = {
+            CaregiverRegistrationScreen(
+                    onNavigateBack = { navController.popBackStack() },
+                    onSuccess = {
                         navController.navigate(Screen.Result.createRoute("caregiver")) {
                             popUpTo(Screen.RoleSelection.route)
                         }

--- a/app/src/main/java/com/ezlevup/ganbyeong24/presentation/screens/caregiver/CaregiverRegistrationScreen.kt
+++ b/app/src/main/java/com/ezlevup/ganbyeong24/presentation/screens/caregiver/CaregiverRegistrationScreen.kt
@@ -1,0 +1,255 @@
+package com.ezlevup.ganbyeong24.presentation.screens.caregiver
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.ezlevup.ganbyeong24.presentation.components.GanbyeongButton
+import com.ezlevup.ganbyeong24.presentation.components.GanbyeongTextField
+import com.ezlevup.ganbyeong24.presentation.theme.GanbyeongTheme
+import org.koin.androidx.compose.koinViewModel
+
+/**
+ * 간병사 등록 화면
+ *
+ * 간병사가 자신의 정보를 등록할 수 있는 화면입니다.
+ *
+ * @param viewModel 간병사 등록 ViewModel
+ * @param onNavigateBack 뒤로가기 콜백
+ * @param onSuccess 등록 성공 시 호출되는 콜백
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CaregiverRegistrationScreen(
+        viewModel: CaregiverRegistrationViewModel = koinViewModel(),
+        onNavigateBack: () -> Unit = {},
+        onSuccess: () -> Unit
+) {
+    val state by viewModel.state.collectAsState()
+
+    // 등록 성공 시 ResultScreen으로 이동
+    LaunchedEffect(state.isSuccess) {
+        if (state.isSuccess) {
+            onSuccess()
+        }
+    }
+
+    Scaffold(
+            topBar = {
+                TopAppBar(
+                        title = { Text("간병사 등록") },
+                        navigationIcon = {
+                            IconButton(onClick = onNavigateBack) {
+                                Icon(Icons.Default.ArrowBack, contentDescription = "뒤로가기")
+                            }
+                        }
+                )
+            }
+    ) { padding ->
+        Column(
+                modifier =
+                        Modifier.fillMaxSize()
+                                .padding(padding)
+                                .verticalScroll(rememberScrollState())
+                                .padding(24.dp)
+        ) {
+            // 이름
+            GanbyeongTextField(
+                    value = state.name,
+                    onValueChange = viewModel::onNameChange,
+                    label = "이름 *",
+                    placeholder = "예: 김영희",
+                    isError = state.nameError != null,
+                    errorMessage = state.nameError,
+                    modifier = Modifier.padding(bottom = 16.dp)
+            )
+
+            // 경력
+            GanbyeongTextField(
+                    value = state.experience,
+                    onValueChange = viewModel::onExperienceChange,
+                    label = "경력 *",
+                    placeholder = "예: 5년",
+                    isError = state.experienceError != null,
+                    errorMessage = state.experienceError,
+                    modifier = Modifier.padding(bottom = 16.dp)
+            )
+
+            // 자격증
+            GanbyeongTextField(
+                    value = state.certificates,
+                    onValueChange = viewModel::onCertificatesChange,
+                    label = "자격증 *",
+                    placeholder = "예: 요양보호사",
+                    isError = state.certificatesError != null,
+                    errorMessage = state.certificatesError,
+                    modifier = Modifier.padding(bottom = 16.dp)
+            )
+
+            // 가능 지역
+            GanbyeongTextField(
+                    value = state.availableRegions,
+                    onValueChange = viewModel::onAvailableRegionsChange,
+                    label = "가능 지역 *",
+                    placeholder = "예: 서울, 경기",
+                    isError = state.availableRegionsError != null,
+                    errorMessage = state.availableRegionsError,
+                    modifier = Modifier.padding(bottom = 16.dp)
+            )
+
+            // 연락처
+            GanbyeongTextField(
+                    value = state.phoneNumber,
+                    onValueChange = viewModel::onPhoneNumberChange,
+                    label = "연락처 *",
+                    placeholder = "010-1111-2222",
+                    isError = state.phoneNumberError != null,
+                    errorMessage = state.phoneNumberError,
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Phone),
+                    modifier = Modifier.padding(bottom = 32.dp)
+            )
+
+            // 등록 버튼
+            GanbyeongButton(
+                    text = "등록하기",
+                    onClick = viewModel::registerCaregiver,
+                    isLoading = state.isLoading
+            )
+        }
+    }
+
+    // 에러 다이얼로그
+    if (state.errorMessage != null) {
+        AlertDialog(
+                onDismissRequest = viewModel::clearError,
+                title = { Text("오류") },
+                text = { Text(state.errorMessage!!) },
+                confirmButton = { TextButton(onClick = viewModel::clearError) { Text("확인") } }
+        )
+    }
+}
+
+// ========== Preview ==========
+
+@Preview(showBackground = true)
+@Composable
+private fun CaregiverRegistrationScreenPreview() {
+    GanbyeongTheme {
+        CaregiverRegistrationScreenContent(
+                state = CaregiverRegistrationState(),
+                onNameChange = {},
+                onExperienceChange = {},
+                onCertificatesChange = {},
+                onAvailableRegionsChange = {},
+                onPhoneNumberChange = {},
+                onSubmit = {},
+                onNavigateBack = {},
+                onClearError = {}
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun CaregiverRegistrationScreenContent(
+        state: CaregiverRegistrationState,
+        onNameChange: (String) -> Unit,
+        onExperienceChange: (String) -> Unit,
+        onCertificatesChange: (String) -> Unit,
+        onAvailableRegionsChange: (String) -> Unit,
+        onPhoneNumberChange: (String) -> Unit,
+        onSubmit: () -> Unit,
+        onNavigateBack: () -> Unit,
+        onClearError: () -> Unit
+) {
+    Scaffold(
+            topBar = {
+                TopAppBar(
+                        title = { Text("간병사 등록") },
+                        navigationIcon = {
+                            IconButton(onClick = onNavigateBack) {
+                                Icon(Icons.Default.ArrowBack, contentDescription = "뒤로가기")
+                            }
+                        }
+                )
+            }
+    ) { padding ->
+        Column(
+                modifier =
+                        Modifier.fillMaxSize()
+                                .padding(padding)
+                                .verticalScroll(rememberScrollState())
+                                .padding(24.dp)
+        ) {
+            GanbyeongTextField(
+                    value = state.name,
+                    onValueChange = onNameChange,
+                    label = "이름 *",
+                    placeholder = "예: 김영희",
+                    isError = state.nameError != null,
+                    errorMessage = state.nameError,
+                    modifier = Modifier.padding(bottom = 16.dp)
+            )
+
+            GanbyeongTextField(
+                    value = state.experience,
+                    onValueChange = onExperienceChange,
+                    label = "경력 *",
+                    placeholder = "예: 5년",
+                    isError = state.experienceError != null,
+                    errorMessage = state.experienceError,
+                    modifier = Modifier.padding(bottom = 16.dp)
+            )
+
+            GanbyeongTextField(
+                    value = state.certificates,
+                    onValueChange = onCertificatesChange,
+                    label = "자격증 *",
+                    placeholder = "예: 요양보호사",
+                    isError = state.certificatesError != null,
+                    errorMessage = state.certificatesError,
+                    modifier = Modifier.padding(bottom = 16.dp)
+            )
+
+            GanbyeongTextField(
+                    value = state.availableRegions,
+                    onValueChange = onAvailableRegionsChange,
+                    label = "가능 지역 *",
+                    placeholder = "예: 서울, 경기",
+                    isError = state.availableRegionsError != null,
+                    errorMessage = state.availableRegionsError,
+                    modifier = Modifier.padding(bottom = 16.dp)
+            )
+
+            GanbyeongTextField(
+                    value = state.phoneNumber,
+                    onValueChange = onPhoneNumberChange,
+                    label = "연락처 *",
+                    placeholder = "010-1111-2222",
+                    isError = state.phoneNumberError != null,
+                    errorMessage = state.phoneNumberError,
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Phone),
+                    modifier = Modifier.padding(bottom = 32.dp)
+            )
+
+            GanbyeongButton(text = "등록하기", onClick = onSubmit, isLoading = state.isLoading)
+        }
+    }
+
+    if (state.errorMessage != null) {
+        AlertDialog(
+                onDismissRequest = onClearError,
+                title = { Text("오류") },
+                text = { Text(state.errorMessage) },
+                confirmButton = { TextButton(onClick = onClearError) { Text("확인") } }
+        )
+    }
+}

--- a/app/src/main/java/com/ezlevup/ganbyeong24/presentation/screens/caregiver/CaregiverRegistrationState.kt
+++ b/app/src/main/java/com/ezlevup/ganbyeong24/presentation/screens/caregiver/CaregiverRegistrationState.kt
@@ -1,0 +1,36 @@
+package com.ezlevup.ganbyeong24.presentation.screens.caregiver
+
+/**
+ * 간병사 등록 화면 상태
+ *
+ * 화면의 모든 상태를 관리하는 데이터 클래스입니다.
+ *
+ * @property isLoading 로딩 상태
+ * @property isSuccess 등록 성공 여부
+ * @property errorMessage 에러 메시지
+ * @property name 이름
+ * @property experience 경력
+ * @property certificates 자격증
+ * @property availableRegions 가능 지역
+ * @property phoneNumber 연락처
+ * @property nameError 이름 에러 메시지
+ * @property experienceError 경력 에러 메시지
+ * @property certificatesError 자격증 에러 메시지
+ * @property availableRegionsError 가능 지역 에러 메시지
+ * @property phoneNumberError 연락처 에러 메시지
+ */
+data class CaregiverRegistrationState(
+        val isLoading: Boolean = false,
+        val isSuccess: Boolean = false,
+        val errorMessage: String? = null,
+        val name: String = "",
+        val experience: String = "",
+        val certificates: String = "",
+        val availableRegions: String = "",
+        val phoneNumber: String = "",
+        val nameError: String? = null,
+        val experienceError: String? = null,
+        val certificatesError: String? = null,
+        val availableRegionsError: String? = null,
+        val phoneNumberError: String? = null
+)

--- a/app/src/main/java/com/ezlevup/ganbyeong24/presentation/screens/caregiver/CaregiverRegistrationViewModel.kt
+++ b/app/src/main/java/com/ezlevup/ganbyeong24/presentation/screens/caregiver/CaregiverRegistrationViewModel.kt
@@ -1,0 +1,135 @@
+package com.ezlevup.ganbyeong24.presentation.screens.caregiver
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.ezlevup.ganbyeong24.data.model.Caregiver
+import com.ezlevup.ganbyeong24.data.repository.CaregiverRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+/**
+ * 간병사 등록 화면 ViewModel
+ *
+ * 간병사 등록 화면의 비즈니스 로직을 담당합니다.
+ *
+ * @property repository 간병사 Repository
+ */
+class CaregiverRegistrationViewModel(private val repository: CaregiverRepository) : ViewModel() {
+
+    private val _state = MutableStateFlow(CaregiverRegistrationState())
+    val state: StateFlow<CaregiverRegistrationState> = _state.asStateFlow()
+
+    // ========== 입력 핸들러 ==========
+
+    fun onNameChange(name: String) {
+        _state.update { it.copy(name = name, nameError = null) }
+    }
+
+    fun onExperienceChange(experience: String) {
+        _state.update { it.copy(experience = experience, experienceError = null) }
+    }
+
+    fun onCertificatesChange(certificates: String) {
+        _state.update { it.copy(certificates = certificates, certificatesError = null) }
+    }
+
+    fun onAvailableRegionsChange(regions: String) {
+        _state.update { it.copy(availableRegions = regions, availableRegionsError = null) }
+    }
+
+    fun onPhoneNumberChange(phoneNumber: String) {
+        _state.update { it.copy(phoneNumber = phoneNumber, phoneNumberError = null) }
+    }
+
+    // ========== 등록 처리 ==========
+
+    /** 간병사 등록을 제출합니다. */
+    fun registerCaregiver() {
+        if (!validateForm()) return
+
+        viewModelScope.launch {
+            _state.update { it.copy(isLoading = true) }
+
+            val caregiver =
+                    Caregiver(
+                            name = _state.value.name,
+                            experience = _state.value.experience,
+                            certificates = _state.value.certificates,
+                            availableRegions = _state.value.availableRegions,
+                            phoneNumber = _state.value.phoneNumber,
+                            status = "pending"
+                    )
+
+            repository
+                    .saveCaregiver(caregiver)
+                    .onSuccess { _state.update { it.copy(isLoading = false, isSuccess = true) } }
+                    .onFailure { error ->
+                        _state.update {
+                            it.copy(
+                                    isLoading = false,
+                                    errorMessage = error.message ?: "알 수 없는 오류가 발생했습니다"
+                            )
+                        }
+                    }
+        }
+    }
+
+    // ========== 유효성 검사 ==========
+
+    /**
+     * 폼 유효성 검사를 수행합니다.
+     *
+     * @return 유효성 검사 통과 여부
+     */
+    private fun validateForm(): Boolean {
+        val errors = mutableMapOf<String, String>()
+
+        // 이름 검증
+        if (_state.value.name.length < 2) {
+            errors["name"] = "이름은 2자 이상 입력해주세요"
+        }
+
+        // 경력 검증
+        if (_state.value.experience.isBlank()) {
+            errors["experience"] = "경력을 입력해주세요"
+        }
+
+        // 자격증 검증
+        if (_state.value.certificates.isBlank()) {
+            errors["certificates"] = "자격증을 입력해주세요"
+        }
+
+        // 가능 지역 검증
+        if (_state.value.availableRegions.isBlank()) {
+            errors["availableRegions"] = "가능 지역을 입력해주세요"
+        }
+
+        // 연락처 검증
+        val phoneRegex = "^010\\d{8}$".toRegex()
+        val cleanPhone = _state.value.phoneNumber.replace("-", "")
+        if (!phoneRegex.matches(cleanPhone)) {
+            errors["phoneNumber"] = "올바른 전화번호 형식이 아닙니다 (010-XXXX-XXXX)"
+        }
+
+        // 에러 업데이트
+        _state.update {
+            it.copy(
+                    nameError = errors["name"],
+                    experienceError = errors["experience"],
+                    certificatesError = errors["certificates"],
+                    availableRegionsError = errors["availableRegions"],
+                    phoneNumberError = errors["phoneNumber"]
+            )
+        }
+
+        return errors.isEmpty()
+    }
+
+    /** 에러 메시지를 초기화합니다. */
+    fun clearError() {
+        _state.update { it.copy(errorMessage = null) }
+    }
+}

--- a/docs/WorkLog.md
+++ b/docs/WorkLog.md
@@ -152,6 +152,37 @@
 - Compose Button 커스터마이징 (높이, 모양, 색상)
 - 네비게이션 콜백 파라미터 명명 규칙
 - ScreenDesign.md 명세를 따른 구현
+- Firestore 데이터 저장 및 조회
+- Repository 패턴 구현
+- ViewModel 유효성 검사 로직
+- Koin 의존성 주입 (Repository, ViewModel)
+
+#### CareRequestScreen 개발
+- [x] **Issue #19**: CareRequestScreen 구현 - 간병 신청 화면
+  - GitHub 이슈 등록 (#19)
+  - feature/care-request 브랜치 생성
+  - 데이터 레이어 구현
+    - CareRequest 데이터 모델 생성
+    - CareRequestRepository 인터페이스 및 구현체
+    - Firestore 연동 (care_requests 컬렉션)
+  - Presentation 레이어 구현
+    - CareRequestState 데이터 클래스
+    - CareRequestViewModel (StateFlow, 유효성 검사)
+  - UI 레이어 구현
+    - CareRequestScreen.kt (8개 입력 필드)
+    - TopAppBar 및 뒤로가기 기능
+    - 유효성 검사 에러 메시지 표시
+    - 로딩 상태 처리
+    - 에러 다이얼로그
+  - Koin 모듈 업데이트
+    - CareRequestRepository 등록
+    - CareRequestViewModel 등록
+  - NavGraph.kt 업데이트
+    - CareRequestScreenPlaceholder → 실제 화면 교체
+  - 빌드 및 실행 테스트 성공
+  - Firestore 저장 테스트 성공
+  - Git commit & push 완료
+  - PR 생성 및 머지 완료 (`feature/care-request` → `develop`)
 
 ---
 
@@ -159,25 +190,25 @@
 
 ### 3단계: 화면 개발 (계속)
 
-#### CareRequestScreen 개발 (다음 작업)
+#### CaregiverRegistrationScreen 개발 (다음 작업)
 - [ ] GitHub 이슈 등록
-- [ ] feature/care-request 브랜치 생성
-- [ ] CareRequestScreen.kt 구현
-  - [ ] 환자명 입력 필드
-  - [ ] 보호자명 입력 필드
-  - [ ] 환자 상태 드롭다운
-  - [ ] 간병 기간 선택
-  - [ ] 위치 입력 필드
-  - [ ] 연락처 입력 필드
-  - [ ] 유효성 검사
-- [ ] CareRequestViewModel 구현
+- [ ] feature/caregiver-registration 브랜치 생성
+- [ ] 데이터 레이어 구현
+  - [ ] Caregiver 데이터 모델
+  - [ ] CaregiverRepository
+- [ ] Presentation 레이어 구현
+  - [ ] CaregiverState
+  - [ ] CaregiverViewModel
+- [ ] UI 레이어 구현
+  - [ ] CaregiverRegistrationScreen.kt
+  - [ ] 입력 필드 및 유효성 검사
 - [ ] 빌드 및 테스트
 - [ ] Git commit & push
 - [ ] PR 생성 및 머지
 
-#### CaregiverRegistrationScreen 개발 (시간 되면)
-- [ ] 간병사 등록 폼 구현
-- [ ] 입력 필드 및 유효성 검사
+#### ResultScreen 개발 (시간 되면)
+- [ ] 완료 화면 구현
+- [ ] 역할별 메시지 표시
 
 ---
 
@@ -186,13 +217,13 @@
 ### 전체 로드맵 (5단계)
 - ✅ 1단계: 프로젝트 초기 설정 (100%)
 - ✅ 2단계: 기반 구축 (100%)
-- 🚧 3단계: 화면 개발 (40% - SplashScreen, RoleSelectionScreen 완료)
+- 🚧 3단계: 화면 개발 (60% - SplashScreen, RoleSelectionScreen, CareRequestScreen 완료)
 - ⏳ 4단계: 데이터 레이어 (0%)
 - ⏳ 5단계: 테스트 및 배포 (0%)
 
 ### GitHub Issues
-- ✅ Closed: #1, #2, #3, #4, #5, #6, #13, #15, #17
-- 📝 Next: CareRequestScreen, CaregiverRegistrationScreen
+- ✅ Closed: #1, #2, #3, #4, #5, #6, #13, #15, #17, #19
+- 📝 Next: CaregiverRegistrationScreen, ResultScreen
 
 ---
 
@@ -201,10 +232,10 @@
 ### 프로젝트 구조
 ```
 com.ezlevup.ganbyeong24/
-├── di/                          # ✅ Koin 모듈
+├── di/                          # ✅ Koin 모듈 (Repository, ViewModel)
 ├── data/
-│   ├── model/                   # CareRequest, Caregiver
-│   └── repository/              # Repository
+│   ├── model/                   # ✅ CareRequest
+│   └── repository/              # ✅ CareRequestRepository
 ├── presentation/
 │   ├── theme/                   # ✅ Color, Type, Theme
 │   ├── components/              # ✅ Button, TextField
@@ -212,7 +243,7 @@ com.ezlevup.ganbyeong24/
 │   └── screens/
 │       ├── splash/              # ✅ SplashScreen (완료)
 │       ├── role/                # ✅ RoleSelectionScreen (완료)
-│       ├── care_request/
+│       ├── care_request/        # ✅ CareRequestScreen (완료)
 │       ├── caregiver/
 │       └── result/
 └── util/
@@ -268,5 +299,5 @@ docs/WorkLog.md 파일 확인해줘.
 
 ---
 
-**마지막 업데이트**: 2026-01-15 14:34
+**마지막 업데이트**: 2026-01-15 15:57
 

--- a/issue_caregiver_registration.md
+++ b/issue_caregiver_registration.md
@@ -1,0 +1,52 @@
+## 🎯 작업 내용
+CaregiverRegistrationScreen 구현 - 간병사 등록 화면
+
+## 📋 상세 설명
+간병사가 자신의 정보를 등록할 수 있는 화면을 구현합니다.
+
+## ✅ 구현 사항
+
+### 데이터 레이어
+- [ ] Caregiver 데이터 모델 생성
+- [ ] CaregiverRepository 인터페이스 생성
+- [ ] CaregiverRepositoryImpl 구현 (Firestore 연동)
+- [ ] Koin 모듈에 Repository 등록
+
+### Presentation 레이어
+- [ ] CaregiverRegistrationState 데이터 클래스 생성
+- [ ] CaregiverRegistrationViewModel 구현
+  - StateFlow 상태 관리
+  - 입력 핸들러 함수들
+  - 유효성 검사 로직
+  - Firestore 저장 로직
+- [ ] Koin 모듈에 ViewModel 등록
+
+### UI 구현
+- [ ] CaregiverRegistrationScreen.kt 파일 생성
+- [ ] TopAppBar (뒤로가기 버튼)
+- [ ] 입력 필드 구현
+  - 이름 (필수)
+  - 경력 (필수)
+  - 자격증 (필수)
+  - 가능 지역 (필수)
+  - 연락처 (필수)
+- [ ] 등록하기 버튼
+- [ ] 에러 다이얼로그
+- [ ] 로딩 상태 처리
+
+### Navigation
+- [ ] NavGraph.kt 업데이트
+  - CaregiverRegistrationScreenPlaceholder를 실제 화면으로 교체
+
+## 🎨 디자인 요구사항
+- Material3 테마 적용
+- 시니어 친화적 큰 폰트
+- 명확한 필수 필드 표시
+- 유효성 검사 에러 메시지 표시
+
+## 📝 참고 문서
+- [ScreenDesign.md](./docs/ScreenDesign.md)
+- [TechnicalDesign.md](./docs/TechnicalDesign.md)
+
+## 🔗 관련 이슈
+- #19 (CareRequestScreen 구현)


### PR DESCRIPTION
## 🎯 작업 내용
CaregiverRegistrationScreen 구현 (#21)
## ✅ 구현 사항
### 데이터 레이어
- Caregiver 데이터 모델 생성
- CaregiverRepository 인터페이스 및 구현체
- Firestore 연동 (caregivers 컬렉션)
### Presentation 레이어
- CaregiverRegistrationState 데이터 클래스
- CaregiverRegistrationViewModel (상태 관리, 유효성 검사)
### UI 레이어
- CaregiverRegistrationScreen.kt (5개 입력 필드)
- TopAppBar 및 뒤로가기 기능
- 유효성 검사 에러 메시지 표시
- 로딩 상태 처리
- 에러 다이얼로그
### Koin DI 설정
- Repository 및 ViewModel 등록
### Navigation
- CaregiverRegistrationScreenPlaceholder → 실제 화면 교체
## 📋 테스트
- [x] 빌드 성공
- [x] UI 정상 표시 확인
- [x] 입력 필드 동작 확인
- [x] 유효성 검사 확인
- [x] Firestore 저장 확인
## 📝 관련 이슈
Closes #21